### PR TITLE
Added rxjs path mappings 

### DIFF
--- a/src/AngularWebpackVisualStudio/config/webpack.dev.js
+++ b/src/AngularWebpackVisualStudio/config/webpack.dev.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const rxPaths = require('rxjs/_esm5/path-mapping');
 
 const webpack = require('webpack');
 
@@ -32,7 +33,8 @@ module.exports = {
     },
 
     resolve: {
-        extensions: ['.ts', '.js', '.json']
+        extensions: ['.ts', '.js', '.json'],
+        alias: rxPaths()
     },
 
     devServer: {
@@ -96,6 +98,8 @@ module.exports = {
         exprContextCritical: false
     },
     plugins: [
+        new webpack.optimize.ModuleConcatenationPlugin(),
+
         new webpack.optimize.CommonsChunkPlugin({ name: ['vendor', 'polyfills'] }),
 
         new CleanWebpackPlugin(

--- a/src/AngularWebpackVisualStudio/config/webpack.prod.js
+++ b/src/AngularWebpackVisualStudio/config/webpack.prod.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const rxPaths = require('rxjs/_esm5/path-mapping');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -27,7 +28,8 @@ module.exports = {
     },
 
     resolve: {
-        extensions: ['.ts', '.js', '.json']
+        extensions: ['.ts', '.js', '.json'],
+        alias: rxPaths()
     },
 
     devServer: {
@@ -89,6 +91,8 @@ module.exports = {
             tsConfigPath: './tsconfig-aot.json'
             // entryModule: './angularApp/app/app.module#AppModule'
         }),
+
+        new webpack.optimize.ModuleConcatenationPlugin(),
 
         new CleanWebpackPlugin(
             [


### PR DESCRIPTION
This way webpack will bundle only the operators that are used in the app and not all of them, resulting in a smaller bundle. This closes #119 

